### PR TITLE
Restore legacy JSON importer support

### DIFF
--- a/server/src/main/java/com/ramussoft/ai/JsonDiagramImporter.java
+++ b/server/src/main/java/com/ramussoft/ai/JsonDiagramImporter.java
@@ -53,14 +53,22 @@ public class JsonDiagramImporter {
 
         JsonNode root = objectMapper.readTree(json);
 
-        if (!root.isArray()) {
-            throw new IllegalArgumentException("Expected top level JSON array");
+        ImportState state = new ImportState();
+
+        ImportResult result;
+        if (root.isArray()) {
+            result = importCompactDiagram(root, state);
+        } else if (root.isObject()) {
+            result = importLegacyDiagram(root, state);
+        } else {
+            throw new IllegalArgumentException("Expected top level JSON array or object");
         }
 
+        return result;
+    }
+
+    private ImportResult importCompactDiagram(JsonNode root, ImportState state) {
         DiagramNode rootNode = new DiagramNode(rootFunction);
-        Map<Long, Function> functions = new LinkedHashMap<>();
-        Map<Long, Stream> streams = new LinkedHashMap<>();
-        Map<Long, Sector> sectors = new LinkedHashMap<>();
 
         List<JsonNode> boxes = new ArrayList<>();
         List<JsonNode> arrows = new ArrayList<>();
@@ -73,7 +81,7 @@ public class JsonDiagramImporter {
             }
         }
 
-        createFunctions(boxes, rootNode, functions);
+        createCompactFunctions(boxes, rootNode, state);
 
         for (JsonNode arrow : arrows) {
             long arrowId = requireLong(arrow, "id");
@@ -85,20 +93,173 @@ public class JsonDiagramImporter {
 
             Stream stream = createStreamForArrow(arrow);
             sector.setStream(stream, ReplaceStreamType.CHILDREN);
-            streams.put(arrowId, stream);
+            state.streams.put(arrowId, stream);
+            state.streamLookup.put(arrowId, stream);
 
             if (sector instanceof NSector) {
-                configureBorders((NSector) sector, arrow, functions);
+                configureBorders((NSector) sector, arrow, state);
                 ((NSector) sector).setShowText(true);
             }
 
-            sectors.put(arrowId, sector);
+            state.sectors.put(arrowId, sector);
         }
 
-        return new ImportResult(functions, streams, sectors);
+        return new ImportResult(state.functions, state.streams, state.sectors);
     }
 
-    private void createFunctions(List<JsonNode> boxes, DiagramNode rootNode, Map<Long, Function> functions) {
+    private ImportResult importLegacyDiagram(JsonNode root, ImportState state) {
+        List<JsonNode> elements = new ArrayList<>();
+        JsonNode elementsNode = root.get("elements");
+        if (elementsNode != null && elementsNode.isArray()) {
+            elementsNode.forEach(elements::add);
+        }
+
+        List<JsonNode> boxes = new ArrayList<>();
+        List<JsonNode> arrows = new ArrayList<>();
+        for (JsonNode element : elements) {
+            String type = textValue(element.get("type"));
+            if ("box".equalsIgnoreCase(type)) {
+                boxes.add(element);
+            } else if ("arrow".equalsIgnoreCase(type)) {
+                arrows.add(element);
+            }
+        }
+
+        JsonNode streamsNode = root.get("streams");
+        if (streamsNode != null && streamsNode.isArray()) {
+            for (JsonNode streamNode : streamsNode) {
+                long streamId = requireLong(streamNode, "id");
+                Stream stream = (Stream) dataPlugin.createRow(dataPlugin.getBaseStream(), true);
+                if (streamNode.has("name")) {
+                    stream.setName(streamNode.path("name").asText(""));
+                }
+                if (streamNode.has("emptyName")) {
+                    stream.setEmptyName(streamNode.path("emptyName").asBoolean(false));
+                } else {
+                    stream.setEmptyName(stream.getName() == null || stream.getName().isEmpty());
+                }
+                state.streams.put(streamId, stream);
+                state.streamLookup.put(streamId, stream);
+            }
+        }
+
+        createLegacyFunctions(boxes, state);
+
+        for (JsonNode arrow : arrows) {
+            long arrowId = requireLong(arrow, "id");
+            JsonNode sectorNode = arrow.get("sector");
+            if (sectorNode == null || !sectorNode.isObject()) {
+                throw new IllegalArgumentException("Arrow element is missing required object 'sector'");
+            }
+
+            long functionId = sectorNode.path("functionId").asLong(0L);
+            Function diagramFunction = resolveFunctionById(state, functionId);
+
+            Sector sector = dataPlugin.createSector();
+            sector.setFunction(diagramFunction);
+            NSector nSector = (NSector) sector;
+
+            JsonNode geometry = sectorNode.get("geometry");
+            if (geometry != null && geometry.isObject()) {
+                int createState = geometry.path("createState").asInt(Sector.STATE_NONE);
+                double createPos = geometry.path("createPos").asDouble(0.5);
+                sector.setCreateState(createState, createPos);
+                sector.setShowText(geometry.path("showText").asInt(1) != 0);
+                if (geometry.has("alternativeText")) {
+                    sector.setAlternativeText(geometry.path("alternativeText").asText(""));
+                }
+                if (geometry.has("textAlignment")) {
+                    sector.setTextAligment(geometry.path("textAlignment").asInt(0));
+                }
+                if (geometry.has("visualAttributes")) {
+                    String visual = geometry.path("visualAttributes").asText("");
+                    if (!visual.isEmpty()) {
+                        sector.setVisualAttributes(decodeBase64(visual));
+                    }
+                }
+            } else {
+                sector.setCreateState(Sector.STATE_NONE, 0.5);
+                sector.setShowText(true);
+            }
+
+            JsonNode labelFrame = sectorNode.get("labelFrame");
+            if (labelFrame != null && labelFrame.isObject()) {
+                SectorPropertiesPersistent properties = nSector.getSectorProperties();
+                if (labelFrame.has("showText")) {
+                    properties.setShowText(labelFrame.path("showText").asInt(properties.getShowText()));
+                }
+                if (labelFrame.has("textX")) {
+                    properties.setTextX(labelFrame.path("textX").asDouble(properties.getTextX()));
+                }
+                if (labelFrame.has("textY")) {
+                    properties.setTextY(labelFrame.path("textY").asDouble(properties.getTextY()));
+                }
+                if (labelFrame.has("textWidth")) {
+                    properties.setTextWidth(labelFrame.path("textWidth").asDouble(properties.getTextWidth()));
+                }
+                if (labelFrame.has("textHeight")) {
+                    properties.setTextHieght(labelFrame.path("textHeight").asDouble(properties.getTextHieght()));
+                }
+                if (labelFrame.has("transparent")) {
+                    properties.setTransparent(labelFrame.path("transparent").asInt(properties.getTransparent()));
+                }
+                if (labelFrame.has("showTilda")) {
+                    properties.setShowTilda(labelFrame.path("showTilda").asInt(properties.getShowTilda()));
+                }
+                nSector.setSectorProperties(properties);
+            }
+
+            JsonNode bendPoints = sectorNode.get("bendPoints");
+            if (bendPoints != null && bendPoints.isArray()) {
+                List<SectorPointPersistent> points = new ArrayList<>();
+                for (JsonNode pointNode : bendPoints) {
+                    SectorPointPersistent point = new SectorPointPersistent();
+                    if (pointNode.has("xOrdinateId")) {
+                        point.setXOrdinateId(pointNode.path("xOrdinateId").asLong(0L));
+                    }
+                    if (pointNode.has("yOrdinateId")) {
+                        point.setYOrdinateId(pointNode.path("yOrdinateId").asLong(0L));
+                    }
+                    if (pointNode.has("x")) {
+                        point.setXPosition(pointNode.path("x").asDouble(0.0));
+                    }
+                    if (pointNode.has("y")) {
+                        point.setYPosition(pointNode.path("y").asDouble(0.0));
+                    }
+                    if (pointNode.has("type")) {
+                        point.setPointType(parsePointType(pointNode.path("type").asText("")));
+                    }
+                    if (pointNode.has("position")) {
+                        point.setPosition(pointNode.path("position").asInt(point.getPosition()));
+                    }
+                    points.add(point);
+                }
+                nSector.setSectorPointPersistents(points);
+            }
+
+            long streamId = sectorNode.path("streamId").asLong(Long.MIN_VALUE);
+            Stream stream = state.streamLookup.get(streamId);
+            if (stream == null) {
+                stream = createStreamForArrow(arrow);
+                if (streamId != Long.MIN_VALUE) {
+                    state.streams.put(streamId, stream);
+                    state.streamLookup.put(streamId, stream);
+                } else {
+                    state.streams.put(arrowId, stream);
+                    state.streamLookup.put(arrowId, stream);
+                }
+            }
+            sector.setStream(stream, ReplaceStreamType.CHILDREN);
+
+            configureLegacyBorders(nSector, sectorNode, state);
+
+            state.sectors.put(arrowId, sector);
+        }
+
+        return new ImportResult(state.functions, state.streams, state.sectors);
+    }
+
+    private void createCompactFunctions(List<JsonNode> boxes, DiagramNode rootNode, ImportState state) {
         List<JsonNode> pending = new ArrayList<>(boxes);
         while (!pending.isEmpty()) {
             boolean progress = false;
@@ -124,8 +285,51 @@ public class JsonDiagramImporter {
                 double height = box.path("height").asDouble(bounds.getHeight());
                 function.setBounds(new FRectangle(x, y, width, height));
 
-                functions.put(id, function);
+                state.functions.put(id, function);
+                state.functionLookup.put(id, function);
                 parentNode.children.put(id, new DiagramNode(function));
+
+                iterator.remove();
+                progress = true;
+            }
+            if (!progress) {
+                throw new IllegalArgumentException("Cannot resolve parents for all box elements");
+            }
+        }
+    }
+
+    private void createLegacyFunctions(List<JsonNode> boxes, ImportState state) {
+        List<JsonNode> pending = new ArrayList<>(boxes);
+        while (!pending.isEmpty()) {
+            boolean progress = false;
+            Iterator<JsonNode> iterator = pending.iterator();
+            while (iterator.hasNext()) {
+                JsonNode box = iterator.next();
+                JsonNode parentNode = box.get("parent");
+                long parentId = parentNode == null ? 0L : parentNode.path("functionId").asLong(0L);
+                Function parent = parentId == 0L ? rootFunction : state.functionLookup.get(parentId);
+                if (parent == null) {
+                    continue;
+                }
+                if (parentNode != null && parentNode.has("diagramType")) {
+                    parent.setDecompositionType(parentNode.path("diagramType").asInt(parent.getDecompositionType()));
+                }
+
+                long id = requireLong(box, "id");
+                Function function = dataPlugin.createFunction(parent, parent.getType());
+                function.setDecompositionType(parent.getDecompositionType());
+                if (box.has("name")) {
+                    function.setName(box.path("name").asText(""));
+                }
+                FRectangle bounds = function.getBounds();
+                double x = box.path("x").asDouble(bounds.getX());
+                double y = box.path("y").asDouble(bounds.getY());
+                double width = box.path("width").asDouble(bounds.getWidth());
+                double height = box.path("height").asDouble(bounds.getHeight());
+                function.setBounds(new FRectangle(x, y, width, height));
+
+                state.functions.put(id, function);
+                state.functionLookup.put(id, function);
 
                 iterator.remove();
                 progress = true;
@@ -144,15 +348,56 @@ public class JsonDiagramImporter {
         return stream;
     }
 
-    private void configureBorders(NSector sector, JsonNode arrow, Map<Long, Function> functions) {
-        Attachment source = parseAttachment(arrow, "source", functions, true);
-        Attachment target = parseAttachment(arrow, "target", functions, false);
+    private void configureBorders(NSector sector, JsonNode arrow, ImportState state) {
+        Attachment source = parseAttachment(arrow, "source", state.functionLookup, true);
+        Attachment target = parseAttachment(arrow, "target", state.functionLookup, false);
 
         NSectorBorder start = sector.getStart();
         applyAttachment(start, source);
 
         NSectorBorder end = sector.getEnd();
         applyAttachment(end, target);
+    }
+
+    private void configureLegacyBorders(NSector sector, JsonNode sectorNode, ImportState state) {
+        configureLegacyBorder(sector.getStart(), sectorNode.get("start"), state, true);
+        configureLegacyBorder(sector.getEnd(), sectorNode.get("end"), state, false);
+    }
+
+    private void configureLegacyBorder(NSectorBorder border, JsonNode node, ImportState state, boolean source) {
+        if (node == null || !node.isObject()) {
+            return;
+        }
+
+        int side = toSide(node.path("functionSide").asText(null), source ? MovingPanel.RIGHT : MovingPanel.LEFT);
+        border.setFunctionTypeA(side);
+
+        if (node.has("borderType")) {
+            border.setBorderTypeA(parseBorderType(node.path("borderType").asText("")));
+        }
+
+        if (node.has("tunnelType")) {
+            border.getSbp().setTunnelSoft(node.path("tunnelType").asInt(border.getSbp().getTunnelSoft()));
+        } else if (node.has("tunnelSoft")) {
+            border.getSbp().setTunnelSoft(node.path("tunnelSoft").asInt(border.getSbp().getTunnelSoft()));
+        }
+
+        long functionId = node.path("functionId").asLong(-1L);
+        Function function = resolveFunctionById(state, functionId);
+        border.setFunctionA(function);
+        if (function == null) {
+            border.setBorderTypeA(SectorBorder.TYPE_BORDER);
+        }
+
+        if (node.has("crosspointId")) {
+            long crosspointId = node.path("crosspointId").asLong(-1L);
+            if (crosspointId >= 0) {
+                Crosspoint crosspoint = resolveCrosspoint(state, crosspointId);
+                border.setCrosspointA(crosspoint);
+            }
+        }
+
+        border.commit();
     }
 
     private Attachment parseAttachment(JsonNode arrow, String field, Map<Long, Function> functions, boolean source) {
@@ -204,6 +449,20 @@ public class JsonDiagramImporter {
 
     private Function resolveDiagramFunction(JsonNode node, DiagramNode rootNode) {
         return resolveNode(node.get("father"), rootNode).function;
+    }
+
+    private Function resolveFunctionById(ImportState state, long functionId) {
+        if (functionId < 0) {
+            return null;
+        }
+        if (functionId == 0L) {
+            return rootFunction;
+        }
+        Function function = state.functionLookup.get(functionId);
+        if (function == null) {
+            throw new IllegalArgumentException("Unknown function id '" + functionId + "'");
+        }
+        return function;
     }
 
     private DiagramNode resolveNode(JsonNode fatherNode, DiagramNode rootNode) {
@@ -299,6 +558,66 @@ public class JsonDiagramImporter {
         return node == null ? null : node.asText(null);
     }
 
+    private int parsePointType(String type) {
+        if (type == null) {
+            return 0;
+        }
+        switch (type.toUpperCase()) {
+            case "MIDDLE":
+                return 1;
+            case "START":
+                return 0;
+            case "END":
+                return 2;
+            default:
+                return 0;
+        }
+    }
+
+    private int parseBorderType(String borderType) {
+        if (borderType == null) {
+            return SectorBorder.TYPE_BORDER;
+        }
+        switch (borderType.toUpperCase()) {
+            case "FUNCTION":
+                return SectorBorder.TYPE_FUNCTION;
+            case "SPOT":
+                return SectorBorder.TYPE_SPOT;
+            case "BORDER":
+            default:
+                return SectorBorder.TYPE_BORDER;
+        }
+    }
+
+    private Crosspoint resolveCrosspoint(ImportState state, long crosspointId) {
+        if (crosspointId < 0) {
+            return null;
+        }
+        Crosspoint crosspoint = state.crosspoints.get(crosspointId);
+        if (crosspoint != null) {
+            return crosspoint;
+        }
+        Crosspoint existing = dataPlugin.findCrosspointByGlobalId(crosspointId);
+        if (existing != null) {
+            crosspoint = existing;
+        } else {
+            crosspoint = dataPlugin.createCrosspoint(crosspointId);
+        }
+        state.crosspoints.put(crosspointId, crosspoint);
+        return crosspoint;
+    }
+
+    private byte[] decodeBase64(String value) {
+        if (value == null || value.isEmpty()) {
+            return new byte[0];
+        }
+        try {
+            return Base64.getDecoder().decode(value);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Invalid base64 value", ex);
+        }
+    }
+
     private long requireLong(JsonNode node, String field) {
         JsonNode value = node.get(field);
         if (value == null || !value.canConvertToLong()) {
@@ -313,6 +632,19 @@ public class JsonDiagramImporter {
 
         private DiagramNode(Function function) {
             this.function = function;
+        }
+    }
+
+    private final class ImportState {
+        private final Map<Long, Function> functions = new LinkedHashMap<>();
+        private final Map<Long, Function> functionLookup = new HashMap<>();
+        private final Map<Long, Stream> streams = new LinkedHashMap<>();
+        private final Map<Long, Stream> streamLookup = new HashMap<>();
+        private final Map<Long, Sector> sectors = new LinkedHashMap<>();
+        private final Map<Long, Crosspoint> crosspoints = new HashMap<>();
+
+        private ImportState() {
+            functionLookup.put(0L, rootFunction);
         }
     }
 

--- a/server/src/test/java/com/ramussoft/ai/JsonDiagramImporterTest.java
+++ b/server/src/test/java/com/ramussoft/ai/JsonDiagramImporterTest.java
@@ -3,24 +3,18 @@ package com.ramussoft.ai;
 import com.dsoft.pb.types.FRectangle;
 import com.ramussoft.common.Engine;
 import com.ramussoft.idef0.NDataPluginFactory;
+import com.ramussoft.idef0.attribute.SectorPointPersistent;
+import com.ramussoft.idef0.attribute.SectorPropertiesPersistent;
+import com.ramussoft.pb.Crosspoint;
 import com.ramussoft.pb.DataPlugin;
 import com.ramussoft.pb.Function;
 import com.ramussoft.pb.Sector;
 import com.ramussoft.pb.Stream;
-<<<<<<< ours
-=======
 import com.ramussoft.pb.data.SectorBorder;
->>>>>>> theirs
 import com.ramussoft.pb.data.negine.NSector;
 import com.ramussoft.pb.data.negine.NSectorBorder;
 import com.ramussoft.pb.idef.visual.MovingArea;
 import com.ramussoft.pb.idef.visual.MovingPanel;
-<<<<<<< ours
-import com.ramussoft.pb.Crosspoint;
-import com.ramussoft.idef0.attribute.SectorPointPersistent;
-import com.ramussoft.idef0.attribute.SectorPropertiesPersistent;
-=======
->>>>>>> theirs
 import com.ramussoft.server.EngineFactory;
 import org.junit.After;
 import org.junit.Before;
@@ -51,8 +45,7 @@ public class JsonDiagramImporterTest {
     }
 
     @Test
-<<<<<<< ours
-    public void importsBoxesStreamsAndArrows() throws Exception {
+    public void importsLegacyDiagramWithDetailedSectorData() throws Exception {
         String json = "{" +
                 "\"streams\":[{" +
                 "\"id\":7,\"name\":\"Material\",\"emptyName\":false" +
@@ -75,45 +68,22 @@ public class JsonDiagramImporterTest {
                 "\"bendPoints\":[{" +
                 "\"xOrdinateId\":1001,\"yOrdinateId\":2001,\"x\":180.0,\"y\":90.0,\"type\":\"MIDDLE\",\"position\":1" +
                 "}]}}]}";
-=======
-    public void importsBoxesAndArrowsFromCompactJson() throws Exception {
-        String json = "[" +
-                "{\"type\":\"box\",\"id\":1,\"name\":\"A1\",\"father\":0,\"x\":120,\"y\":80,\"width\":140,\"height\":90}," +
-                "{\"type\":\"box\",\"id\":2,\"name\":\"A2\",\"father\":0,\"x\":320,\"y\":80,\"width\":140,\"height\":90}," +
-                "{\"type\":\"box\",\"id\":3,\"name\":\"A1.1\",\"father\":1,\"x\":140,\"y\":140,\"width\":120,\"height\":70}," +
-                "{\"type\":\"box\",\"id\":4,\"name\":\"A1.2\",\"father\":1,\"x\":320,\"y\":140,\"width\":120,\"height\":70}," +
-                "{\"type\":\"arrow\",\"id\":10,\"name\":\"Material\",\"father\":0,\"source\":1,\"sourceSide\":\"RIGHT\",\"target\":2,\"targetSide\":\"LEFT\"}," +
-                "{\"type\":\"arrow\",\"id\":11,\"name\":\"External\",\"father\":0,\"source\":\"LEFT\",\"target\":1,\"targetSide\":\"LEFT\"}," +
-                "{\"type\":\"arrow\",\"id\":12,\"name\":\"Detail\",\"father\":1,\"source\":3,\"sourceSide\":\"RIGHT\",\"target\":4,\"targetSide\":\"LEFT\"}," +
-                "{\"type\":\"arrow\",\"id\":13,\"name\":\"Output\",\"father\":1,\"source\":4,\"sourceSide\":\"RIGHT\",\"target\":\"RIGHT\",\"targetSide\":\"RIGHT\"}" +
-                "]";
->>>>>>> theirs
 
         JsonDiagramImporter importer = new JsonDiagramImporter(dataPlugin, baseFunction);
         JsonDiagramImporter.ImportResult result = importer.importDiagram(json);
 
         Map<Long, Function> functions = result.getFunctions();
-<<<<<<< ours
         assertEquals(2, functions.size());
 
         Function box1 = functions.get(12L);
         assertNotNull(box1);
         assertEquals("A1", box1.getName());
-=======
-        assertEquals(4, functions.size());
-
-        Function box1 = functions.get(1L);
-        assertNotNull(box1);
-        assertEquals("A1", box1.getName());
         assertEquals(MovingArea.DIAGRAM_TYPE_DFD, box1.getDecompositionType());
->>>>>>> theirs
         FRectangle bounds1 = box1.getBounds();
         assertEquals(120.0, bounds1.getX(), 0.001);
         assertEquals(80.0, bounds1.getY(), 0.001);
         assertEquals(140.0, bounds1.getWidth(), 0.001);
         assertEquals(90.0, bounds1.getHeight(), 0.001);
-<<<<<<< ours
-        assertEquals(MovingArea.DIAGRAM_TYPE_DFD, box1.getDecompositionType());
 
         Function box2 = functions.get(18L);
         assertNotNull(box2);
@@ -122,6 +92,7 @@ public class JsonDiagramImporterTest {
         Map<Long, Stream> streams = result.getStreams();
         assertTrue(streams.containsKey(7L));
         Stream stream = streams.get(7L);
+        assertNotNull(stream);
         assertEquals("Material", stream.getName());
 
         Sector sector = result.getSectors().get(34L);
@@ -133,14 +104,14 @@ public class JsonDiagramImporterTest {
         assertEquals(1, sector.getCreateState());
         assertEquals(0.5, sector.getCreatePos(), 0.0001);
 
-        NSectorBorder start = (NSectorBorder) ((NSector) sector).getStart();
+        NSectorBorder start = sector.getStart();
         assertEquals(box1, start.getFunction());
         assertEquals(MovingPanel.RIGHT, start.getFunctionType());
         Crosspoint crosspoint = start.getCrosspoint();
         assertNotNull(crosspoint);
         assertEquals(301L, crosspoint.getGlobalId());
 
-        NSectorBorder end = (NSectorBorder) ((NSector) sector).getEnd();
+        NSectorBorder end = sector.getEnd();
         assertEquals(box2, end.getFunction());
         assertEquals(MovingPanel.LEFT, end.getFunctionType());
         assertEquals(crosspoint, end.getCrosspoint());
@@ -160,9 +131,35 @@ public class JsonDiagramImporterTest {
         assertEquals(1, point.getPointType());
         assertEquals(1, point.getPosition());
     }
-}
 
-=======
+    @Test
+    public void importsBoxesAndArrowsFromCompactJson() throws Exception {
+        String json = "[" +
+                "{\"type\":\"box\",\"id\":1,\"name\":\"A1\",\"father\":0,\"x\":120,\"y\":80,\"width\":140,\"height\":90}," +
+                "{\"type\":\"box\",\"id\":2,\"name\":\"A2\",\"father\":0,\"x\":320,\"y\":80,\"width\":140,\"height\":90}," +
+                "{\"type\":\"box\",\"id\":3,\"name\":\"A1.1\",\"father\":1,\"x\":140,\"y\":140,\"width\":120,\"height\":70}," +
+                "{\"type\":\"box\",\"id\":4,\"name\":\"A1.2\",\"father\":1,\"x\":320,\"y\":140,\"width\":120,\"height\":70}," +
+                "{\"type\":\"arrow\",\"id\":10,\"name\":\"Material\",\"father\":0,\"source\":1,\"sourceSide\":\"RIGHT\",\"target\":2,\"targetSide\":\"LEFT\"}," +
+                "{\"type\":\"arrow\",\"id\":11,\"name\":\"External\",\"father\":0,\"source\":\"LEFT\",\"target\":1,\"targetSide\":\"LEFT\"}," +
+                "{\"type\":\"arrow\",\"id\":12,\"name\":\"Detail\",\"father\":1,\"source\":3,\"sourceSide\":\"RIGHT\",\"target\":4,\"targetSide\":\"LEFT\"}," +
+                "{\"type\":\"arrow\",\"id\":13,\"name\":\"Output\",\"father\":1,\"source\":4,\"sourceSide\":\"RIGHT\",\"target\":\"RIGHT\",\"targetSide\":\"RIGHT\"}" +
+                "]";
+
+        JsonDiagramImporter importer = new JsonDiagramImporter(dataPlugin, baseFunction);
+        JsonDiagramImporter.ImportResult result = importer.importDiagram(json);
+
+        Map<Long, Function> functions = result.getFunctions();
+        assertEquals(4, functions.size());
+
+        Function box1 = functions.get(1L);
+        assertNotNull(box1);
+        assertEquals("A1", box1.getName());
+        assertEquals(MovingArea.DIAGRAM_TYPE_DFD, box1.getDecompositionType());
+        FRectangle bounds1 = box1.getBounds();
+        assertEquals(120.0, bounds1.getX(), 0.001);
+        assertEquals(80.0, bounds1.getY(), 0.001);
+        assertEquals(140.0, bounds1.getWidth(), 0.001);
+        assertEquals(90.0, bounds1.getHeight(), 0.001);
 
         Function box3 = functions.get(3L);
         assertNotNull(box3);
@@ -218,4 +215,3 @@ public class JsonDiagramImporterTest {
         assertEquals(MovingPanel.RIGHT, end13.getFunctionType());
     }
 }
->>>>>>> theirs


### PR DESCRIPTION
## Summary
- extend JsonDiagramImporter to support both the compact and the legacy diagram JSON structures, including legacy stream and sector metadata
- add a regression test that verifies the detailed legacy import scenario alongside the compact JSON coverage

## Testing
- `./gradlew --console=plain :server:test --tests com.ramussoft.ai.JsonDiagramImporterTest` *(fails: Gradle cannot compile settings.gradle because of "Unsupported class file major version 65")*

------
https://chatgpt.com/codex/tasks/task_e_68ce84dfd3f8832f8d8439c7b51ba6d3