### PR TITLE
fix: ensure gradle wrapper verifies distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,20 @@ In the console, navigate to the project folder and run:
 
 4. Now, you can simply run `ramus` in the terminal to launch the application.
 
+## Troubleshooting
+
+### "java.util.zip.ZipException: error in opening zip file" on Windows
+
+If the Gradle wrapper download becomes corrupted (for example, when the build stops with
+`java.util.zip.ZipException: error in opening zip file` while unpacking `gradle-6.9.4-all.zip`),
+remove the cached distribution and rerun the command. Gradle will download a fresh copy on the
+next invocation.
+
+```powershell
+Remove-Item "$env:USERPROFILE\.gradle\wrapper\dists" -Recurse -Force
+```
+
+If you prefer to delete only the failing version, remove the specific directory shown in the error
+message instead of the whole `dists` folder. After the cleanup, re-run `./gradlew build` (or any
+other Gradle wrapper command) and the build should proceed normally.
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,3 +4,4 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.4-all.zip
+distributionSha256Sum=84b50e7b380e9dc9bbc81e30a8eb45371527010cf670199596c86875f774b8b0


### PR DESCRIPTION
## Summary
- add the official SHA-256 checksum so the Gradle wrapper re-downloads a corrupted distribution archive automatically

## Testing
- ./gradlew help *(fails on JDK 21 because Gradle 6.9.4 cannot compile the Groovy settings script)*

------
https://chatgpt.com/codex/tasks/task_e_68dccac6cae4832fab203d536d7617d0